### PR TITLE
Update URL of Slack API Token page

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -211,7 +211,7 @@
 				<key>plusspaces</key>
 				<false/>
 				<key>url</key>
-				<string>https://api.slack.com/</string>
+				<string>https://api.slack.com/web#auth</string>
 				<key>utf8</key>
 				<true/>
 			</dict>


### PR DESCRIPTION
はじめまして。素晴らしい Alfred workflow ありがとうございます！

以下の Qiita ページにもコメントしましたが、先程試してみたところ Slack の URL に変更があった様ですのでその内容を workflow に反映してみました。よろしければご確認ください。

[AlfredでSlackのチャンネルを開く](http://qiita.com/akira-hamada/items/1e391704d68d0af5e65e#comment-a3b3b6a4b99faade0745)

なお、alfredworkflow ファイルは更新しておりません。